### PR TITLE
更新 A onclick 逻辑

### DIFF
--- a/example/router.js
+++ b/example/router.js
@@ -84,15 +84,29 @@ const processStack = () => Object.keys(stack).forEach(process)
 
 window.addEventListener('popstate', processStack)
 
-export function A (props) {
-  const { onClick: onclick } = props
+function isModifiedEvent(event) {
+  return !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
+}
+
+export function A(props) {
+  const {onClick: onclick, children} = props
 
   const onClick = e => {
-    e.preventDefault()
-    push(e.target.href)
-
     if (onclick) onclick(e)
+    if (
+      !event.defaultPrevented && // onClick prevented default
+      event.button === 0 && // ignore everything but left clicks
+      (!props.target || props.target === '_self') && // let browser handle "target=_blank" etc.
+      !isModifiedEvent(event) // ignore clicks with modifier keys
+    ) {
+      e.preventDefault()
+      push(e.target.href)
+    }
   }
 
-  return <a {...props} onClick={onClick} />
+  return (
+    <a {...props} onClick={onClick}>
+      {children}
+    </a>
+  )
 }

--- a/src/index.js
+++ b/src/index.js
@@ -82,13 +82,24 @@ const processStack = () =>{
 
 window.addEventListener('popstate', processStack)
 
+function isModifiedEvent(event) {
+  return !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
+}
+
 export function A(props) {
   const {onClick: onclick, children} = props
 
   const onClick = e => {
-    e.preventDefault()
-    push(e.target.href)
     if (onclick) onclick(e)
+    if (
+      !event.defaultPrevented && // onClick prevented default
+      event.button === 0 && // ignore everything but left clicks
+      (!props.target || props.target === '_self') && // let browser handle "target=_blank" etc.
+      !isModifiedEvent(event) // ignore clicks with modifier keys
+    ) {
+      e.preventDefault()
+      push(e.target.href)
+    }
   }
 
   return (


### PR DESCRIPTION
1. 当用户调用 `event.preventDefault()`, a 标签应中止跳转
2. 当用户使用右键点击, 应由浏览器默认弹出 context 菜单, 而非跳转
3. 当用户使用中键点击或 `ctrl` 加左键点击, 应无视 `target` 属性, 在新标签页建立新页面
4. 当 `target` 为 `__blank` 时, 应在新标签页建立新页面

...
and so on